### PR TITLE
Fix deployment page application error

### DIFF
--- a/components/enhanced-ui.tsx
+++ b/components/enhanced-ui.tsx
@@ -1,6 +1,7 @@
 "use client"
 
 import { motion } from "framer-motion"
+import { useEffect, useState } from "react"
 import { Card } from "@/components/ui/card"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
@@ -8,6 +9,22 @@ import { Sparkles, Target, Rocket, Code2, Globe, ArrowRight, Calendar, Clock } f
 
 // Enhanced floating animation component
 export function FloatingElements() {
+  const [viewport, setViewport] = useState<{ width: number; height: number }>({ width: 1000, height: 800 })
+
+  useEffect(() => {
+    const updateSize = () => {
+      // Guard for environments where window is not defined (SSR/build)
+      if (typeof window === "undefined") return
+      setViewport({ width: window.innerWidth, height: window.innerHeight })
+    }
+
+    updateSize()
+    if (typeof window !== "undefined") {
+      window.addEventListener("resize", updateSize)
+      return () => window.removeEventListener("resize", updateSize)
+    }
+  }, [])
+
   return (
     <div className="absolute inset-0 overflow-hidden pointer-events-none">
       {/* Animated background particles */}
@@ -16,12 +33,12 @@ export function FloatingElements() {
           key={i}
           className="absolute w-2 h-2 bg-primary/20 rounded-full"
           initial={{
-            x: Math.random() * window.innerWidth,
-            y: Math.random() * window.innerHeight,
+            x: Math.random() * viewport.width,
+            y: Math.random() * viewport.height,
           }}
           animate={{
-            x: Math.random() * window.innerWidth,
-            y: Math.random() * window.innerHeight,
+            x: Math.random() * viewport.width,
+            y: Math.random() * viewport.height,
           }}
           transition={{
             duration: Math.random() * 10 + 10,


### PR DESCRIPTION
Fixes application error on deployment page by safely accessing window dimensions in `FloatingElements`.

The `FloatingElements` component was accessing `window.innerWidth` and `window.innerHeight` directly during render. This caused a server-side crash during Server-Side Rendering (SSR) on Vercel because `window` is undefined in that environment. The change moves the viewport dimension access into a `useEffect` hook, ensuring it only runs on the client-side and guards against `window` being undefined.

---
<a href="https://cursor.com/background-agent?bcId=bc-7a9faaf6-c36b-4d0f-bbdf-0952e630f69b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-7a9faaf6-c36b-4d0f-bbdf-0952e630f69b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

